### PR TITLE
M4 integration follow-up: edge-case hardening + hint cleanup/tests

### DIFF
--- a/tests/engine/hints.test.ts
+++ b/tests/engine/hints.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getActiveHint } from "../../src/ui/hints";
+
+const baseContext = {
+  turn: 1,
+  supply: 3,
+  maxSupply: 5,
+  mode: "map",
+};
+
+describe("getActiveHint", () => {
+  it("returns first-turn hint on turn zero", () => {
+    const hint = getActiveHint({ ...baseContext, turn: 0 }, new Set());
+    expect(hint?.id).toBe("first-turn");
+  });
+
+  it("returns null when first-turn hint is dismissed", () => {
+    const hint = getActiveHint({ ...baseContext, turn: 0 }, new Set(["first-turn"]));
+    expect(hint).toBeNull();
+  });
+
+  it("returns null when no hint condition matches", () => {
+    const hint = getActiveHint(baseContext, new Set());
+    expect(hint).toBeNull();
+  });
+
+  it("applies priority ordering when multiple hints match", () => {
+    const hint = getActiveHint(
+      { ...baseContext, turn: 0, supply: 1, mode: "encounter" },
+      new Set(),
+    );
+    expect(hint?.id).toBe("first-turn");
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared hint overlay renderer and reuse in map/encounter views
- remove unused `drawLegend` `_canvasHeight` parameter
- add unit tests for `getActiveHint` priority and dismissal behavior
- harden edge-case handling by applying pre-action loss checks in `resolveTurn`
- suppress repeated keydown events to reduce rapid-input runaway actions
- document `restart()` hint persistence as intentional player-knowledge behavior

## Validation
- pnpm -s vitest run tests/engine/hints.test.ts
- pnpm -s vitest run tests/engine/turn.test.ts tests/engine/hints.test.ts
- pnpm -s vitest run
- pnpm -s tsc --noEmit
- pnpm -s build

Fixes #42
Fixes #43
Fixes #44
Refs #34
Refs #37