### PR TITLE
fix: harden turn handling for edge-case loss and rapid input

### DIFF
--- a/src/engine/turn.ts
+++ b/src/engine/turn.ts
@@ -440,15 +440,20 @@ export function resolveTurn(state: GameState, action: Action, rng: RNG): GameSta
     return state;
   }
 
+  const checkedState = applyLossChecks(state);
+  if (checkedState.status !== "playing") {
+    return checkedState;
+  }
+
   if (action.type === "choose") {
-    return handleChoose(state, action, rng);
+    return handleChoose(checkedState, action, rng);
   }
 
   if (action.type === "dismiss") {
-    return handleDismiss(state);
+    return handleDismiss(checkedState);
   }
 
-  const advancedState = { ...state, turn: state.turn + 1 };
+  const advancedState = { ...checkedState, turn: checkedState.turn + 1 };
 
   if (action.type === "push") {
     return handlePush(advancedState, action, rng);

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,6 +256,10 @@ async function main(): Promise<void> {
   };
 
   document.addEventListener("keydown", (event) => {
+    if (event.repeat) {
+      return;
+    }
+
     const normalizedKey = event.key.toLowerCase();
 
     if (state.mode.type === "gameover" && event.key === "Enter") {

--- a/tests/engine/turn.test.ts
+++ b/tests/engine/turn.test.ts
@@ -445,6 +445,25 @@ describe("resolveTurn searing and loss flow", () => {
     expect(next.status).toBe("lost");
     expect(next.mode.type).toBe("gameover");
   });
+
+  it("triggers game over immediately when the player is already on a consumed hex", () => {
+    const { state, rng } = makeState();
+    const next = resolveTurn(
+      {
+        ...state,
+        player: { ...state.player, hex: { q: 0, r: 0, s: 0 } },
+        searing: { ...state.searing, axis: "q", direction: 1, line: 0 },
+      },
+      { type: "pause", activity: "rest" },
+      rng,
+    );
+
+    expect(next.status).toBe("lost");
+    expect(next.mode.type).toBe("gameover");
+    if (next.mode.type === "gameover") {
+      expect(next.mode.reason).toContain("Searing catches you");
+    }
+  });
 });
 
 describe("frost proximity signals", () => {


### PR DESCRIPTION
## Summary

- **Pre-check loss on every turn**: `resolveTurn` now calls `applyLossChecks` before processing any action, so a player already standing on a consumed hex triggers game over immediately (not on next movement)
- **Guard key repeat**: Added `event.repeat` guard in `main.ts` keydown handler to prevent held keys from processing multiple turns
- **New test**: covers the "player starts on consumed hex + pause action → immediate game over" edge case

## Test plan
- [x] `npm test` passes (125 tests, +1 from this branch)
- [x] `npm run typecheck` passes
- [x] Cherry-picked onto current main (PR #51 base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)