### PR TITLE
feat: low-hope visual desaturation and log flicker (CRI-117)

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,26 @@
         font-style: italic;
       }
 
+      @keyframes flicker {
+        0%   { opacity: 1; }
+        8%   { opacity: 0.7; }
+        10%  { opacity: 1; }
+        60%  { opacity: 1; }
+        62%  { opacity: 0.5; }
+        64%  { opacity: 1; }
+        100% { opacity: 1; }
+      }
+
+      #log-panel[data-hope-level="low"] .log-narrative {
+        animation: flicker 4s infinite;
+        color: #a0a0a0;
+      }
+
+      #log-panel[data-hope-level="critical"] .log-narrative {
+        animation: flicker 1.8s infinite;
+        color: #787878;
+      }
+
       @media (max-width: 768px) {
         body {
           overflow-y: auto;

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { createInitialState, MAX_SUPPLY, type Action, type GameState } from "./e
 import { resolveTurn } from "./engine/turn";
 import { screenToWorld } from "./renderer/camera";
 import { getActiveHint, type HintId } from "./ui/hints";
-import { clearLog, updateLog } from "./ui/log";
+import { applyHopeStyling, clearLog, updateLog } from "./ui/log";
 import {
   playMove,
   playEncounterOpen,
@@ -252,6 +252,7 @@ async function main(): Promise<void> {
     );
     camera = render(ctx, state, camera, activeHint);
     updateLog(logPanel, state.log);
+    applyHopeStyling(logPanel, state.player.hope);
     window.requestAnimationFrame(frame);
   };
 

--- a/src/renderer/views/map.ts
+++ b/src/renderer/views/map.ts
@@ -1,6 +1,6 @@
 import { coordKey } from "../../engine/hex";
 import { getVisibleNeighbors } from "../../engine/map";
-import { type GameState, type HexTile } from "../../engine/state";
+import { type GameState, type HexTile, MAX_HOPE } from "../../engine/state";
 import { drawHexagon, hexToPixel, HEX_SIZE } from "../canvas";
 import type { Camera } from "../camera";
 import { worldToScreen } from "../camera";
@@ -8,6 +8,8 @@ import { COLORS, BIOME_GLYPHS } from "../glyphs";
 import { renderHud } from "../hud";
 import { drawHintOverlay, type ActiveHint } from "../hint-overlay";
 import { drawLegend } from "../legend";
+
+const LOW_HOPE_THRESHOLD = Math.floor(MAX_HOPE * 0.4);
 
 function searingDistance(state: GameState): number {
   const playerAxisValue = state.player.hex[state.searing.axis];
@@ -125,6 +127,12 @@ export function renderMap(
   const shimmerPhase = (now / 800) % (Math.PI * 2);
   const pulsePhase = (now / 600) % (Math.PI * 2);
 
+  const { hope } = state.player;
+  if (hope <= LOW_HOPE_THRESHOLD) {
+    const saturation = Math.round((hope / LOW_HOPE_THRESHOLD) * 80);
+    ctx.filter = `saturate(${saturation}%)`;
+  }
+
   for (const tile of state.map.values()) {
     drawTile(ctx, tile, camera, width, height, shimmerPhase);
   }
@@ -149,7 +157,9 @@ export function renderMap(
   ctx.fillText("@", playerScreen.x, playerScreen.y);
   ctx.restore();
 
+  ctx.filter = "none";
   drawSearingEdgeGlow(ctx, width, height, searingDistance(state), pulsePhase);
+
 
   renderHud(ctx, state, width);
   drawLegend(ctx, width, "map");

--- a/src/ui/log.ts
+++ b/src/ui/log.ts
@@ -27,3 +27,13 @@ export function updateLog(panel: HTMLElement, entries: LogEntry[]): void {
 export function clearLog(panel: HTMLElement): void {
   panel.replaceChildren();
 }
+
+export function applyHopeStyling(panel: HTMLElement, hope: number): void {
+  if (hope <= 1) {
+    panel.dataset.hopeLevel = "critical";
+  } else if (hope <= 2) {
+    panel.dataset.hopeLevel = "low";
+  } else {
+    delete panel.dataset.hopeLevel;
+  }
+}


### PR DESCRIPTION
## Summary

Adds canvas desaturation and log flicker visual effects when player hope drops to critical levels.

- **Canvas desaturation**: As hope drops to/below 40% of max, the map canvas `saturate()` filter scales from 80% → 0%, creating a washed-out tension effect
- **Log flicker**: Log text gets a CSS `flicker` animation at low hope (≤2) and a faster flicker at critical hope (≤1), with dimmed text color
- **Filter reset**: `ctx.filter = "none"` resets before searing edge glow rendering (no interference)

## What changed
- `index.html` — CSS `@keyframes flicker` + `[data-hope-level="low"/"critical"]` selectors on `#log-panel .log-narrative`
- `src/ui/log.ts` — new `applyHopeStyling(panel, hope)` export
- `src/main.ts` — call `applyHopeStyling` each frame after `updateLog`
- `src/renderer/views/map.ts` — `LOW_HOPE_THRESHOLD`, canvas filter on map render, reset before searing glow

## Conflict resolution
Rebased onto main after searing drama (`feat/searing-visual-drama`) and edge-case fixes were merged. Kept both the shimmer/pulse animation setup AND the hope desaturation filter. Filter is reset before `drawSearingEdgeGlow` so both effects compose correctly.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)